### PR TITLE
add tests for clear and make clear not blow up when passed options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.5.1
+  * make clear not blow up when options are passed
+
 ## 0.5.0
   * Use Memcached#exist if available (performance improvement ~25%)
   * Correctly escape bad characters and too long keys

--- a/lib/active_support/cache/libmemcached_store.rb
+++ b/lib/active_support/cache/libmemcached_store.rb
@@ -168,7 +168,7 @@ module ActiveSupport
         values
       end
 
-      def clear
+      def clear(options = nil)
         @cache.flush
       end
 

--- a/test/active_support/libmemcached_store_test.rb
+++ b/test/active_support/libmemcached_store_test.rb
@@ -326,4 +326,22 @@ class LibmemcachedStoreTest < MiniTest::Unit::TestCase
     cache.silence!
     assert cache.silence?
   end
+
+  def test_clear
+    @cache.write("xxx", 1)
+    assert_equal 1, @cache.read("xxx")
+    @cache.clear
+
+    # everything is gone
+    assert_nil @cache.read("xxx")
+  end
+
+  def test_clear_with_options
+    @cache.write("xxx", 1)
+    assert_equal 1, @cache.read("xxx")
+    @cache.clear(:some_option => true) # does not blow up
+
+    # everything is gone
+    assert_nil @cache.read("xxx")
+  end
 end


### PR DESCRIPTION
to avoid blowing up when called via acivesupports local-cache

```
       def clear(options = nil) # :nodoc:
          local_cache.clear(options) if local_cache
          super
        end
```
