### PR TITLE
Same exception handling in read_multi as in read_entry

### DIFF
--- a/lib/active_support/cache/libmemcached_store.rb
+++ b/lib/active_support/cache/libmemcached_store.rb
@@ -166,8 +166,6 @@ module ActiveSupport
           values[mapping[key]] = deserialize(value, options[:raw], flags[key])
         end
         values
-      rescue Memcached::NotFound
-        {}
       rescue Memcached::Error => e
         log_error(e)
         {}


### PR DESCRIPTION
This just adds the same exception handling to `read_multi` as `read_entry` has.
