### PR TITLE
read multi vs namespace/normalized/escaped keys

### DIFF
--- a/test/active_support/libmemcached_local_store_test.rb
+++ b/test/active_support/libmemcached_local_store_test.rb
@@ -127,5 +127,14 @@ describe ActiveSupport::Cache::LibmemcachedLocalStore do
       assert_equal expected, store.read_multi('a', 'b', 'c')
       assert_equal({}, store.read_multi)
     end
+
+    it "can read interchangeable keys with read_multi" do
+      @cache.with_local_cache do
+        @cache.write 'x', 1 # write plain key
+        @cache.read_multi('x').must_equal('x' => 1)
+        @memcache.set 'x', 2
+        @cache.read_multi(['x']).must_equal('x' => 1) # reads normalized key
+      end
+    end
   end
 end


### PR DESCRIPTION
moves read multi logic down to the key level, so local cache only uses keys and namespaced / not namespaces or escaped vs unescaped no longer matter

@ccocchi just second commit, first is normalize keys PR