### PR TITLE
LibmemcachedLocalStore increment and decrement default values

### DIFF
--- a/lib/active_support/cache/libmemcached_local_store.rb
+++ b/lib/active_support/cache/libmemcached_local_store.rb
@@ -62,7 +62,7 @@ module ActiveSupport
       end
 
       # memcached returns a fixnum on increment, but the value that is stored is raw / a string
-      def increment(key, amount, options={})
+      def increment(key, amount = 1, options={})
         result = super
         if result && (cache = local_cache)
           cache.write(key, result.to_s)
@@ -71,7 +71,7 @@ module ActiveSupport
       end
 
       # memcached returns a fixnum on decrement, but the value that is stored is raw / a string
-      def decrement(key, amount, options={})
+      def decrement(key, amount = 1, options={})
         result = super
         if result && (cache = local_cache)
           cache.write(key, result.to_s)

--- a/test/active_support/libmemcached_local_store_test.rb
+++ b/test/active_support/libmemcached_local_store_test.rb
@@ -53,11 +53,23 @@ describe ActiveSupport::Cache::LibmemcachedLocalStore do
     @cache.read('x').must_equal "2"
   end
 
+  it_wawo "can increment with default" do
+    @cache.write 'x', 0, raw: true
+    @cache.increment 'x'
+    @cache.read('x').must_equal "1"
+  end
+
   it_wawo "can decrement" do
     @cache.write 'x', 3, raw: true
     @cache.decrement 'x', 1
     @cache.decrement 'x', 1
     @cache.read('x').must_equal "1"
+  end
+
+  it_wawo "can decrement with default" do
+    @cache.write 'x', 3, raw: true
+    @cache.decrement 'x'
+    @cache.read('x').must_equal "2"
   end
 
   describe 'reading nil with locale store' do


### PR DESCRIPTION
Our tests extend [MemoryStore](http://api.rubyonrails.org/classes/ActiveSupport/Cache/MemoryStore.html), which contains defaults for increment and decrement, so calls like `Rails.cache.increment(key)` would pass tests but raise on production.

Make it consistent with [LibmemcachedStore](https://github.com/ccocchi/libmemcached_store/blob/5720e9158958d9daad7a3beebf281de18f129859/lib/active_support/cache/libmemcached_store.rb#L159) and [ActiveSupport::Cache::MemoryStore](http://api.rubyonrails.org/classes/ActiveSupport/Cache/MemoryStore.html#method-i-increment).

/cc @ccocchi @grosser 