### PR TITLE
Consider :prefix_key client option when trimming key length

### DIFF
--- a/lib/active_support/cache/libmemcached_store.rb
+++ b/lib/active_support/cache/libmemcached_store.rb
@@ -75,10 +75,9 @@ module ActiveSupport
         if options[:namespace]
           client_options[:prefix_key] = options.delete(:namespace)
           client_options[:prefix_delimiter] = ':'
-          @namespace_length = client_options[:prefix_key].length + 1
-        else
-          @namespace_length = 0
         end
+        @namespace_length = "#{client_options[:prefix_key]}#{client_options[:prefix_delimiter]}".force_encoding("BINARY").size
+
         client_options[:default_ttl] = options.delete(:expires_in).to_i if options[:expires_in]
 
         @options = {compress_threshold: DEFAULT_COMPRESS_THRESHOLD}.merge(options)

--- a/test/active_support/libmemcached_store_test.rb
+++ b/test/active_support/libmemcached_store_test.rb
@@ -295,6 +295,12 @@ describe ActiveSupport::Cache::LibmemcachedStore do
       really_long_keys_test
     end
 
+    it "really_long_keys_with_client_prefix" do
+      @cache = ActiveSupport::Cache.lookup_store(:libmemcached_store, :expires_in => 60, :client => { :prefix_key => 'namespace', :prefix_delimiter => ':'})
+      @cache.silence!
+      really_long_keys_test
+    end
+
     describe "#clear" do
       it "clears" do
         @cache.write("foo", "bar")


### PR DESCRIPTION
We have a use case to re-use the same memcached client parameters between Rails.cache and other client instances. In the existing implementation, if you replace a :namespace with the direct client :prefix_key and :prefix_delimiter parameters, the @namespace_length is not calculated.

This manifests itself strangely. I would expect long keys to result in a ABadKeyWasProvidedOrCharactersOutOfRange exception. Instead the first read causes a NotFound exception. This ejects the server and causes subsequent queries to raise ServerMarkedDead exceptions until the retry_timeout is reached. This appears to be caused by the [GetWithFlags implementation](https://github.com/ccocchi/libmemcached_store/blob/v0.8.1/lib/memcached/get_with_flags.rb#L31):

```ruby
(byebug) Memcached::Lib.memcached_get_rvalue(@struct, 'foo')
["\x04\bI\"\nbarv2\x06:\x06ET", 0, 0]
(byebug) Memcached::Lib.memcached_get_rvalue(@struct, 'a' * 250)
["", 1446809712, 14] # Lib::MEMCACHED_NOTFOUND
(byebug) Memcached::Lib.memcached_get_rvalue(@struct, 'a' * 250)
["", 1446809712, 35] # Lib::MEMCACHED_SERVER_MARKED_DEAD
```

/cc @grosser 