### PR TITLE
ActiveSupport::Cache::Store.instrument is deprecated on rails 4 ... s…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.6
   - 2.2.3

--- a/lib/active_support/cache/libmemcached_store.rb
+++ b/lib/active_support/cache/libmemcached_store.rb
@@ -329,13 +329,17 @@ module ActiveSupport
       def instrument(operation, key, options=nil)
         log(operation, key, options)
 
-        if ActiveSupport::Cache::Store.instrument
+        if instrument?
           payload = { :key => key }
           payload.merge!(options) if options.is_a?(Hash)
           ActiveSupport::Notifications.instrument("cache_#{operation}.active_support", payload){ yield(payload) }
         else
           yield(nil)
         end
+      end
+
+      def instrument?
+        ActiveSupport::VERSION::MAJOR == 3 ? ActiveSupport::Cache::Store.instrument : true
       end
 
       def log(operation, key, options=nil)

--- a/libmemcached_store.gemspec
+++ b/libmemcached_store.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.files       = `git ls-files lib`.split("\n")
 
+  s.required_ruby_version = '>= 2.0.0'
+
   s.add_dependency('memcached')
 
   s.add_development_dependency('rack')

--- a/test/active_support/libmemcached_store_test.rb
+++ b/test/active_support/libmemcached_store_test.rb
@@ -49,7 +49,9 @@ describe ActiveSupport::Cache::LibmemcachedStore do
     end
 
     def listen_to_instrumentation
-      old, ActiveSupport::Cache::Store.instrument = ActiveSupport::Cache::Store.instrument, true
+      if ActiveSupport::VERSION::MAJOR == 3
+        old, ActiveSupport::Cache::Store.instrument = ActiveSupport::Cache::Store.instrument, true
+      end
       called = []
       key = //
       ActiveSupport::Notifications.subscribe(key) do |*args|
@@ -60,7 +62,9 @@ describe ActiveSupport::Cache::LibmemcachedStore do
       called
     ensure
       ActiveSupport::Notifications.unsubscribe(key)
-      ActiveSupport::Cache::Store.instrument = old
+      if ActiveSupport::VERSION::MAJOR == 3
+        ActiveSupport::Cache::Store.instrument = old
+      end
     end
 
     it "fetch_without_cache_miss" do


### PR DESCRIPTION
…o stop using it

@ccocchi 